### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ATLAS (Adaptive Task & Logic Automation System) is a Model Context Protocol server that provides hierarchical task management capabilities to Large Language Models. This tool provides LLMs with the structure and context needed to manage complex tasks and dependencies.
 
+<a href="https://glama.ai/mcp/servers/b8veo1exod"><img width="380" height="200" src="https://glama.ai/mcp/servers/b8veo1exod/badge" alt="atlas-mcp-server MCP server" /></a>
+
 ## Table of Contents
 
 - [Overview](#overview)


### PR DESCRIPTION
This PR adds a badge for the atlas-mcp-server server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/b8veo1exod"><img width="380" height="200" src="https://glama.ai/mcp/servers/b8veo1exod/badge" alt="atlas-mcp-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.