### PR TITLE
Fix parent-child relationship issues

### DIFF
--- a/src/storage/sqlite-storage.ts
+++ b/src/storage/sqlite-storage.ts
@@ -450,17 +450,9 @@ export class SqliteStorage implements TaskStorage {
                 return [];
             }
 
-            // Get all tasks that are either:
-            // 1. Listed in parent's subtasks array
-            // 2. Have this parent_path set
-            const subtaskPaths = parent.subtasks;
-            const placeholders = subtaskPaths.map(() => '?').join(',');
-            
+            // Get tasks that have this parent path
             const rows = await this.db.all<Record<string, unknown>[]>(
-                `SELECT * FROM tasks WHERE 
-                 path IN (${placeholders || "''"}) OR 
-                 parent_path = ?`,
-                ...subtaskPaths,
+                `SELECT * FROM tasks WHERE parent_path = ?`,
                 parentPath
             );
 

--- a/src/task/core/indexing/index-manager.ts
+++ b/src/task/core/indexing/index-manager.ts
@@ -83,14 +83,22 @@ export class TaskIndexManager {
             }
             statusPaths.add(task.path);
 
-            // Update parent index
+            // Update parent index and parent's subtasks
             if (task.parentPath) {
+                // Update parent index
                 let children = this.parentIndex.get(task.parentPath);
                 if (!children) {
                     children = new Set();
                     this.parentIndex.set(task.parentPath, children);
                 }
                 children.add(task.path);
+
+                // Update parent's subtasks array
+                const parentTask = this.taskIndexes.get(task.parentPath);
+                if (parentTask && !parentTask.subtasks.includes(task.path)) {
+                    parentTask.subtasks = [...parentTask.subtasks, task.path];
+                    this.taskIndexes.set(task.parentPath, parentTask);
+                }
             }
 
             // Update dependency index


### PR DESCRIPTION
This PR fixes issues with parent-child relationships in the Atlas MCP Server:

## Changes

- Fix get_subtasks returning empty results
- Simplify SQLite storage getSubtasks implementation to use parent_path directly
- Enhance parent-child relationship consistency
- Update index manager to maintain bidirectional relationships
- Improve task store subtask handling

## Testing

Tested with fresh database:
1. Created parent milestone task
2. Added multiple child tasks
3. Verified bidirectional relationships:
   - get_subtasks returns all children
   - Parent's subtasks array contains all children
   - Children have correct parentPath set

All tests passed successfully.